### PR TITLE
Overriding finalizeSnapshot Method with priority parameter

### DIFF
--- a/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
+++ b/src/main/kotlin/org/opensearch/replication/repository/RemoteClusterRepository.kt
@@ -74,6 +74,7 @@ import java.util.UUID
 import java.util.function.Consumer
 import java.util.function.Function
 import kotlin.collections.ArrayList
+import org.opensearch.common.Priority;
 
 const val REMOTE_REPOSITORY_PREFIX = "replication-remote-repo-"
 const val REMOTE_REPOSITORY_TYPE = "replication-remote-repository"
@@ -116,12 +117,19 @@ class RemoteClusterRepository(private val repositoryMetadata: RepositoryMetadata
     }
 
     override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
-                                  snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
-                                  stateTransformer: Function<ClusterState, ClusterState>?,
-                                  listener: ActionListener<RepositoryData>?) {
-        throw UnsupportedOperationException("Operation not permitted")
+    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+    stateTransformer: Function<ClusterState, ClusterState>?,
+    listener: ActionListener<RepositoryData>?) {
+    throw UnsupportedOperationException("Operation not permitted")
     }
 
+    override fun finalizeSnapshot(shardGenerations: ShardGenerations?, repositoryStateId: Long, clusterMetadata: Metadata?,
+    snapshotInfo: SnapshotInfo?, repositoryMetaVersion: Version?,
+    stateTransformer: Function<ClusterState, ClusterState>?, repositoryUpdatePriority: Priority,
+    listener: ActionListener<RepositoryData>?) {
+    throw UnsupportedOperationException("Operation not permitted")
+    }
+    
     override fun deleteSnapshots(snapshotIds: MutableCollection<SnapshotId>?, repositoryStateId: Long,
                                  repositoryMetaVersion: Version?, listener: ActionListener<RepositoryData>?) {
         throw UnsupportedOperationException("Operation not permitted")


### PR DESCRIPTION
### Description
Added an override function for finalizeSnapshot inlcuding an external parameter Priority.
### Related Issues
CCR Build was getting failed due to change in finalizeSnapshot method in OpenSearch repository and hence needed to overridden.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/cross-cluster-replication/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
